### PR TITLE
Change CIVIC load to be asynchronous

### DIFF
--- a/Filters/CivicCookieControlFilter.cs
+++ b/Filters/CivicCookieControlFilter.cs
@@ -37,7 +37,7 @@ namespace Etch.OrchardCore.CivicCookieControl.Filters
 
                     if (settings?.IsValid ?? false)
                     {
-                        _scriptsCache = new HtmlString($"<script src=\"https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js\"></script><script>var config = {_cookieControlSettingsService.ToJson(settings)}; CookieControl.load( config );</script>");
+                        _scriptsCache = new HtmlString($"<script src=\"https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js\" async></script><script>var config = {_cookieControlSettingsService.ToJson(settings)}; window.onload = function() {{ CookieControl.load( config ); }}</script>");
                     }
                 }
 


### PR DESCRIPTION
Added `async` attribute to `script` element that loads external CIVIC library. This meant that the initialisation of CIVIC (via `CookieControl.load`) has been moved to a window.onload function.

Resolves #14.