### PR TITLE
Fix async loading

### DIFF
--- a/Etch.OrchardCore.CivicCookieControl.csproj
+++ b/Etch.OrchardCore.CivicCookieControl.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.3.1-rc2</Version>
+    <Version>0.3.2-rc2</Version>
     <PackageId>Etch.OrchardCore.CivicCookieControl</PackageId>
     <Title>CIVIC Cookie Control</Title>
     <Authors>Etch UK Ltd.</Authors>

--- a/Filters/CivicCookieControlFilter.cs
+++ b/Filters/CivicCookieControlFilter.cs
@@ -37,7 +37,7 @@ namespace Etch.OrchardCore.CivicCookieControl.Filters
 
                     if (settings?.IsValid ?? false)
                     {
-                        _scriptsCache = new HtmlString($"<script src=\"https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js\" async></script><script>var config = {_cookieControlSettingsService.ToJson(settings)}; window.onload = function() {{ CookieControl.load( config ); }}</script>");
+                        _scriptsCache = new HtmlString($"<script>window.loadCivic=function(){{var config = {_cookieControlSettingsService.ToJson(settings)};CookieControl.load(config);}}</script></script><script src=\"https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js\" onload=\"window.loadCivic()\" async></script>");
                     }
                 }
 

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Add Cookie Control by CIVIC.",
     Name = "CIVIC Cookie Control",
-    Version = "0.3.1",
+    Version = "0.3.2",
     Website = "https://etchuk.com",
     Dependencies = new[]
     {


### PR DESCRIPTION
Listening to `window.onload` can cause a race condition that means CIVIC doesn't get initialised. To resolve this the `onload` is added to the `script` tag that is asynchronously loaded.