### PR TITLE
Add additional fields to widget for customise text content

### DIFF
--- a/Migrations.cs
+++ b/Migrations.cs
@@ -15,6 +15,10 @@ namespace Etch.OrchardCore.CivicCookieControl
 {
     public class Migrations : DataMigration
     {
+        private const string RawCookieContentTypeName = "RawCookie";
+        private const string PredefinedListEditor = "PredefinedList";
+        private const string TextAreaEditor = "TextArea";
+
         #region Dependencies
 
         private readonly IContentDefinitionManager _contentDefinitionManager;
@@ -41,7 +45,7 @@ namespace Etch.OrchardCore.CivicCookieControl
 
         public int UpdateFrom1()
         {
-            _contentDefinitionManager.AlterPartDefinition("CivicCookieControl", builder => builder
+            _contentDefinitionManager.AlterPartDefinition(nameof(Models.CivicCookieControl), builder => builder
                 .WithField("ApiKey", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("API Key")
@@ -54,7 +58,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                 .WithField("Product", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Product")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("2")
                     .WithSettings(new TextFieldSettings
                     {
@@ -92,7 +96,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                 .WithField("InitialState", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Initial State")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("3")
                     .WithSettings(new TextFieldSettings
                     {
@@ -158,7 +162,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                 .WithField("AcceptBehaviour", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Accept Behaviour")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("6")
                     .WithSettings(new TextFieldSettings
                     {
@@ -210,7 +214,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("Intro", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Intro")
-                    .WithEditor("TextArea")
+                    .WithEditor(TextAreaEditor)
                     .WithPosition("9")
                     .WithSettings(new TextFieldSettings
                     {
@@ -229,7 +233,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("NecessaryDescription", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Necessary Description")
-                    .WithEditor("TextArea")
+                    .WithEditor(TextAreaEditor)
                     .WithPosition("11")
                     .WithSettings(new TextFieldSettings
                     {
@@ -248,7 +252,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("ThirdPartyDescription", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Third Party Description")
-                    .WithEditor("TextArea")
+                    .WithEditor(TextAreaEditor)
                     .WithPosition("13")
                     .WithSettings(new TextFieldSettings
                     {
@@ -285,7 +289,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("StatementDescription", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Statement Description")
-                    .WithEditor("TextArea")
+                    .WithEditor(TextAreaEditor)
                     .WithPosition("15")
                     .WithSettings(new TextFieldSettings
                     {
@@ -313,7 +317,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("Layout", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Layout")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("18")
                     .WithSettings(new TextFieldSettings
                     {
@@ -346,7 +350,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("Position", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Position")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("19")
                     .WithSettings(new TextFieldSettings
                     {
@@ -379,7 +383,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("Theme", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Theme")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("20")
                     .WithSettings(new TextFieldSettings
                     {
@@ -412,7 +416,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("ToggleType", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Toggle Type")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("21")
                     .WithSettings(new TextFieldSettings
                     {
@@ -445,7 +449,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("CloseStyle", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Close Style")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("22")
                     .WithSettings(new TextFieldSettings
                     {
@@ -483,7 +487,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField("SettingsStyle", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Settings Style")
-                    .WithEditor("PredefinedList")
+                    .WithEditor(PredefinedListEditor)
                     .WithPosition("23")
                     .WithSettings(new TextFieldSettings
                     {
@@ -515,7 +519,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                     }))
                 );
 
-            _contentDefinitionManager.AlterTypeDefinition("CivicCookieControl", builder => builder
+            _contentDefinitionManager.AlterTypeDefinition(nameof(Models.CivicCookieControl), builder => builder
                 .Stereotype("Widget")
                 .MergeSettings(JObject.FromObject(new
                 {
@@ -524,7 +528,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                     Icon = "cookie"
                 }))
                 .DisplayedAs("CIVIC Cookie Control")
-                .WithPart("CivicCookieControl", builder => builder
+                .WithPart(nameof(Models.CivicCookieControl), builder => builder
                     .WithPosition("1"))
                 .WithPart("OptionalCookies", nameof(BagPart), builder => builder
                     .WithPosition("2")
@@ -532,11 +536,11 @@ namespace Etch.OrchardCore.CivicCookieControl
                     .WithDescription("Collection of cookies used on the site.")
                     .WithSettings(new BagPartSettings
                     {
-                        ContainedContentTypes = new string[] { "RawCookie" }
+                        ContainedContentTypes = new string[] { RawCookieContentTypeName }
                     }))
                 );
 
-            _contentDefinitionManager.AlterPartDefinition("RawCookie", builder => builder
+            _contentDefinitionManager.AlterPartDefinition(RawCookieContentTypeName, builder => builder
                 .WithField("Name", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Name")
@@ -548,7 +552,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                 .WithField("Description", field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Description")
-                    .WithEditor("TextArea")
+                    .WithEditor(TextAreaEditor)
                     .WithPosition("3")
                     .WithSettings(new TextFieldSettings
                     {
@@ -580,7 +584,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                         Language = "javascript"
                     })));
 
-            _contentDefinitionManager.AlterTypeDefinition("RawCookie", builder => builder
+            _contentDefinitionManager.AlterTypeDefinition(RawCookieContentTypeName, builder => builder
                 .MergeSettings(JObject.FromObject(new
                 {
                     Category = "Content",
@@ -590,7 +594,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                 .DisplayedAs("Raw Cookie")
                 .WithPart(nameof(TitlePart), builder => builder
                     .WithPosition("0"))
-                .WithPart("RawCookie", builder => builder
+                .WithPart(RawCookieContentTypeName, builder => builder
                     .WithPosition("1")));
 
             return 2;
@@ -598,7 +602,7 @@ namespace Etch.OrchardCore.CivicCookieControl
 
         public int UpdateFrom2()
         {
-            _contentDefinitionManager.AlterPartDefinition("CivicCookieControl", builder => builder
+            _contentDefinitionManager.AlterPartDefinition(nameof(Models.CivicCookieControl), builder => builder
                 .WithField(nameof(Models.CivicCookieControl.AcceptAllButtonLabel), field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Accept All Button Label")
@@ -659,7 +663,7 @@ namespace Etch.OrchardCore.CivicCookieControl
                  .WithField(nameof(Models.CivicCookieControl.NotifyDescription), field => field
                     .OfType(nameof(TextField))
                     .WithDisplayName("Notify Description")
-                    .WithEditor("TextArea")
+                    .WithEditor(TextAreaEditor)
                     .WithPosition("15")
                     .WithSettings(new TextFieldSettings
                     {

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -1,4 +1,4 @@
-﻿using Etch.OrchardCore.Fields.Code.Fields;
+using Etch.OrchardCore.Fields.Code.Fields;
 using Etch.OrchardCore.Fields.Code.Settings;
 using Etch.OrchardCore.Fields.Values.Fields;
 using Etch.OrchardCore.Fields.Values.Settings;
@@ -594,6 +594,80 @@ namespace Etch.OrchardCore.CivicCookieControl
                     .WithPosition("1")));
 
             return 2;
+        }
+
+        public int UpdateFrom2()
+        {
+            _contentDefinitionManager.AlterPartDefinition("CivicCookieControl", builder => builder
+                .WithField(nameof(Models.CivicCookieControl.AcceptAllButtonLabel), field => field
+                    .OfType(nameof(TextField))
+                    .WithDisplayName("Accept All Button Label")
+                    .WithPosition("14")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Hint = "Text used within the general, affirmative button for opting into all available options."
+                    }))
+                .WithField(nameof(Models.CivicCookieControl.RejectAllButtonLabel), field => field
+                    .OfType(nameof(TextField))
+                    .WithDisplayName("Reject All Button Label")
+                    .WithPosition("15")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Hint = "Text used within the general, affirmative button for opting into all available options."
+                    }))
+                .WithField(nameof(Models.CivicCookieControl.CloseButtonLabel), field => field
+                    .OfType(nameof(TextField))
+                    .WithDisplayName("Close Button Label")
+                    .WithPosition("16")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Hint = "The text used to describe the control button to dismiss Cookie Control. Depending on close style this property may only be read by screen readers."
+                    }))
+                .WithField(nameof(Models.CivicCookieControl.OnToggleLabel), field => field
+                    .OfType(nameof(TextField))
+                    .WithDisplayName("On Toggle Label")
+                    .WithPosition("17")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Hint = "The descriptive text use on the preference control to indicate the user has consented."
+                    }))
+                .WithField(nameof(Models.CivicCookieControl.OffToggleLabel), field => field
+                    .OfType(nameof(TextField))
+                    .WithDisplayName("Off Toggle Label")
+                    .WithPosition("18")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Hint = "The descriptive text use on the preference control to indicate the user has not consented."
+                    }))
+                .WithField(nameof(Models.CivicCookieControl.SettingsLabel), field => field
+                    .OfType(nameof(TextField))
+                    .WithDisplayName("Settings Button Label")
+                    .WithPosition("19")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Hint = "The text used within the control button to open the main preference panel."
+                    }))
+                .WithField(nameof(Models.CivicCookieControl.NotifyTitle), field => field
+                    .OfType(nameof(TextField))
+                    .WithDisplayName("Notify Title")
+                    .WithPosition("14")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Required = false,
+                        Hint = "Heading text used to announce the use of cookies for initial displays such as notify."
+                    }))
+                 .WithField(nameof(Models.CivicCookieControl.NotifyDescription), field => field
+                    .OfType(nameof(TextField))
+                    .WithDisplayName("Notify Description")
+                    .WithEditor("TextArea")
+                    .WithPosition("15")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Required = false,
+                        Hint = "Main body text used to describe the use of cookies for initial displays such as notify."
+                    })));
+
+            return 3;
         }
 
         #endregion

--- a/Models/CivicCookieControl.cs
+++ b/Models/CivicCookieControl.cs
@@ -1,4 +1,4 @@
-﻿using Etch.OrchardCore.Fields.Code.Fields;
+using Etch.OrchardCore.Fields.Code.Fields;
 using Etch.OrchardCore.Fields.Values.Fields;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentFields.Fields;
@@ -11,8 +11,10 @@ namespace Etch.OrchardCore.CivicCookieControl.Models
 {
     public class CivicCookieControl : ContentPart
     {
+        public TextField AcceptAllButtonLabel { get; set; }
         public TextField AcceptBehaviour { get; set; }
         public TextField ApiKey { get; set; }
+        public TextField CloseButtonLabel { get; set; }
         public BooleanField CloseOnGlobalChange { get; set; }
         public TextField CloseStyle { get; set; }
         public TextField InitialState { get; set; }
@@ -21,10 +23,16 @@ namespace Etch.OrchardCore.CivicCookieControl.Models
         public ValuesField NecessaryCookies { get; set; }
         public TextField NecessaryDescription { get; set; }
         public TextField NecessaryTitle { get; set; }
+        public TextField NotifyDescription { get; set; }
         public BooleanField NotifyOnce { get; set; }
+        public TextField NotifyTitle { get; set; }
+        public TextField OffToggleLabel { get; set; }
+        public TextField OnToggleLabel { get; set; }
         public TextField Position { get; set; }
         public TextField Product { get; set; }
+        public TextField RejectAllButtonLabel { get; set; }
         public BooleanField RejectButton { get; set; }
+        public TextField SettingsLabel { get; set; }
         public TextField SettingsStyle { get; set; }
         public TextField StatementDescription { get; set; }
         public TextField StatementName { get; set; }
@@ -66,6 +74,16 @@ namespace Etch.OrchardCore.CivicCookieControl.Models
             AddString((JObject)json["text"], "necessaryDescription", NecessaryDescription.Text);
             AddString((JObject)json["text"], "thirdPartyTitle", ThirdPartyTitle.Text);
             AddString((JObject)json["text"], "thirdPartyDescription", ThirdPartyDescription.Text);
+            AddString((JObject)json["text"], "acceptSettings", AcceptAllButtonLabel?.Text);
+            AddString((JObject)json["text"], "rejectSettings", RejectAllButtonLabel?.Text);
+            AddString((JObject)json["text"], "closeLabel", CloseButtonLabel?.Text);
+            AddString((JObject)json["text"], "on", OnToggleLabel?.Text);
+            AddString((JObject)json["text"], "off", OffToggleLabel?.Text);
+            AddString((JObject)json["text"], "settings", SettingsLabel?.Text);
+            AddString((JObject)json["text"], "notifyTitle", NotifyTitle?.Text);
+            AddString((JObject)json["text"], "notifyDescription", NotifyDescription?.Text);
+            AddString((JObject)json["text"], "accept", AcceptAllButtonLabel?.Text);
+            AddString((JObject)json["text"], "reject", RejectAllButtonLabel?.Text);
 
             json["optionalCookies"] = CreateOptionalCookies(ContentItem.Get<BagPart>("OptionalCookies")?.ContentItems ?? new List<ContentItem>());
 

--- a/Models/CivicCookieControl.cs
+++ b/Models/CivicCookieControl.cs
@@ -11,6 +11,9 @@ namespace Etch.OrchardCore.CivicCookieControl.Models
 {
     public class CivicCookieControl : ContentPart
     {
+        private const string StatementPropertyName = "statement";
+        private const string TextPropertyName = "text";
+
         public TextField AcceptAllButtonLabel { get; set; }
         public TextField AcceptBehaviour { get; set; }
         public TextField ApiKey { get; set; }
@@ -66,35 +69,35 @@ namespace Etch.OrchardCore.CivicCookieControl.Models
                 ["subDomains"] = Subdomains.Value
             };
 
-            json["text"] = new JObject();
+            json[TextPropertyName] = new JObject();
 
-            AddString((JObject)json["text"], "title", Title.Text);
-            AddString((JObject)json["text"], "intro", Intro.Text);
-            AddString((JObject)json["text"], "necessaryTitle", NecessaryTitle.Text);
-            AddString((JObject)json["text"], "necessaryDescription", NecessaryDescription.Text);
-            AddString((JObject)json["text"], "thirdPartyTitle", ThirdPartyTitle.Text);
-            AddString((JObject)json["text"], "thirdPartyDescription", ThirdPartyDescription.Text);
-            AddString((JObject)json["text"], "acceptSettings", AcceptAllButtonLabel?.Text);
-            AddString((JObject)json["text"], "rejectSettings", RejectAllButtonLabel?.Text);
-            AddString((JObject)json["text"], "closeLabel", CloseButtonLabel?.Text);
-            AddString((JObject)json["text"], "on", OnToggleLabel?.Text);
-            AddString((JObject)json["text"], "off", OffToggleLabel?.Text);
-            AddString((JObject)json["text"], "settings", SettingsLabel?.Text);
-            AddString((JObject)json["text"], "notifyTitle", NotifyTitle?.Text);
-            AddString((JObject)json["text"], "notifyDescription", NotifyDescription?.Text);
-            AddString((JObject)json["text"], "accept", AcceptAllButtonLabel?.Text);
-            AddString((JObject)json["text"], "reject", RejectAllButtonLabel?.Text);
+            AddString((JObject)json[TextPropertyName], "title", Title.Text);
+            AddString((JObject)json[TextPropertyName], "intro", Intro.Text);
+            AddString((JObject)json[TextPropertyName], "necessaryTitle", NecessaryTitle.Text);
+            AddString((JObject)json[TextPropertyName], "necessaryDescription", NecessaryDescription.Text);
+            AddString((JObject)json[TextPropertyName], "thirdPartyTitle", ThirdPartyTitle.Text);
+            AddString((JObject)json[TextPropertyName], "thirdPartyDescription", ThirdPartyDescription.Text);
+            AddString((JObject)json[TextPropertyName], "acceptSettings", AcceptAllButtonLabel?.Text);
+            AddString((JObject)json[TextPropertyName], "rejectSettings", RejectAllButtonLabel?.Text);
+            AddString((JObject)json[TextPropertyName], "closeLabel", CloseButtonLabel?.Text);
+            AddString((JObject)json[TextPropertyName], "on", OnToggleLabel?.Text);
+            AddString((JObject)json[TextPropertyName], "off", OffToggleLabel?.Text);
+            AddString((JObject)json[TextPropertyName], "settings", SettingsLabel?.Text);
+            AddString((JObject)json[TextPropertyName], "notifyTitle", NotifyTitle?.Text);
+            AddString((JObject)json[TextPropertyName], "notifyDescription", NotifyDescription?.Text);
+            AddString((JObject)json[TextPropertyName], "accept", AcceptAllButtonLabel?.Text);
+            AddString((JObject)json[TextPropertyName], "reject", RejectAllButtonLabel?.Text);
 
             json["optionalCookies"] = CreateOptionalCookies(ContentItem.Get<BagPart>("OptionalCookies")?.ContentItems ?? new List<ContentItem>());
 
             if (HasStatement)
             {
-                json["statement"] = new JObject();
+                json[StatementPropertyName] = new JObject();
 
-                AddString((JObject)json["statement"], "description", StatementDescription.Text);
-                AddString((JObject)json["statement"], "name", StatementName.Text);
-                AddString((JObject)json["statement"], "url", StatementUrl.Text);
-                AddString((JObject)json["statement"], "updated", StatementUpdated.Value.Value.ToString("dd/MM/yyyy"));
+                AddString((JObject)json[StatementPropertyName], "description", StatementDescription.Text);
+                AddString((JObject)json[StatementPropertyName], "name", StatementName.Text);
+                AddString((JObject)json[StatementPropertyName], "url", StatementUrl.Text);
+                AddString((JObject)json[StatementPropertyName], "updated", StatementUpdated.Value.Value.ToString("dd/MM/yyyy"));
             }
 
             return json.ToString();

--- a/placement.json
+++ b/placement.json
@@ -128,6 +128,62 @@
       ]
     },
     {
+      "place": "Parts#Text:26",
+      "differentiator": "CivicCookieControl-NotifyTitle",
+      "contentType": [
+        "CivicCookieControl"
+      ]
+    },
+    {
+      "place": "Parts#Text:27",
+      "differentiator": "CivicCookieControl-NotifyDescription",
+      "contentType": [
+        "CivicCookieControl"
+      ]
+    },
+    {
+      "place": "Parts#Labels:25",
+      "differentiator": "CivicCookieControl-AcceptAllButtonLabel",
+      "contentType": [
+        "CivicCookieControl"
+      ]
+    },
+    {
+      "place": "Parts#Labels:26",
+      "differentiator": "CivicCookieControl-RejectAllButtonLabel",
+      "contentType": [
+        "CivicCookieControl"
+      ]
+    },
+    {
+      "place": "Parts#Labels:27",
+      "differentiator": "CivicCookieControl-CloseButtonLabel",
+      "contentType": [
+        "CivicCookieControl"
+      ]
+    },
+    {
+      "place": "Parts#Labels:28",
+      "differentiator": "CivicCookieControl-OnToggleLabel",
+      "contentType": [
+        "CivicCookieControl"
+      ]
+    },
+    {
+      "place": "Parts#Labels:29",
+      "differentiator": "CivicCookieControl-OffToggleLabel",
+      "contentType": [
+        "CivicCookieControl"
+      ]
+    },
+    {
+      "place": "Parts#Labels:30",
+      "differentiator": "CivicCookieControl-SettingsLabel",
+      "contentType": [
+        "CivicCookieControl"
+      ]
+    },
+    {
       "place": "Parts#Statement:40",
       "differentiator": "CivicCookieControl-StatementName",
       "contentType": [


### PR DESCRIPTION
Added new fields that allows content editors to customise the text properties that are defined in the CIVIC cookie control configuration.